### PR TITLE
Fixed issue #2

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -34,7 +34,9 @@ MyApplet.prototype = {
 		try {
 
 			// Create the popup menu
+			this.menuManager = new PopupMenu.PopupMenuManager(this);
 			this.menu = new Applet.AppletPopupMenu(this, orientation);
+			this.menuManager.addMenu(this.menu);
 
         	this.sensorsPath = this._detectSensors();
 


### PR DESCRIPTION
Adding the menu to the menuManager to close it automatically on focus lost.
This solves the problem where the menu does not close when the user clicks elsewhere on the screen.
